### PR TITLE
Allow working with multiple movables from vizkit

### DIFF
--- a/src/modifiable_scene/scene.cpp
+++ b/src/modifiable_scene/scene.cpp
@@ -2,6 +2,7 @@
 #include <osg/ShapeDrawable>
 #include <osg/PositionAttitudeTransform>
 #include <iostream>
+#include <stdexcept>
 
 
 namespace modifiable_scene{

--- a/src/modifiable_scene/scene.cpp
+++ b/src/modifiable_scene/scene.cpp
@@ -39,6 +39,10 @@ osg::Matrix Scene::get_transform(std::string name){
     return manipulatable(name)->get_transform();
 }
 
+void Scene::set_transform(std::string name, osg::Matrix transform){
+    return manipulatable(name)->set_transform(transform);
+}
+
 void Scene::add_movable(std::string name, osg::ref_ptr<osg::Node> scene){
 
     osg::ref_ptr<Manipulatable> ptr = new Manipulatable(scene);

--- a/src/modifiable_scene/scene.h
+++ b/src/modifiable_scene/scene.h
@@ -18,6 +18,7 @@ public:
 
     std::vector<std::pair<std::string, osg::Matrix> > get_transforms();
     osg::Matrix get_transform(std::string name);
+    void set_transform(std::string name, osg::Matrix transform);
     void add_movable(std::string name, osg::ref_ptr<osg::Node> scene);
     void add_movable_from_mesh_file(std::string name, std::string filepath, double scale=1.f);
     void remove_movable(const std::string &name);

--- a/src/modifiable_scene/scene.h
+++ b/src/modifiable_scene/scene.h
@@ -7,6 +7,7 @@
 #include <osg/Geometry>
 #include <osg/CoordinateSystemNode>
 #include <vector>
+#include <map>
 
 
 namespace modifiable_scene{
@@ -19,14 +20,15 @@ public:
     osg::Matrix get_transform(std::string name);
     void add_movable(std::string name, osg::ref_ptr<osg::Node> scene);
     void add_movable_from_mesh_file(std::string name, std::string filepath, double scale=1.f);
-
+    void remove_movable(const std::string &name);
+    
     inline SceneItem& target(){return _target;}
     osg::ref_ptr<Manipulatable> manipulatable(std::string name);
 
 
 private:
     SceneItem _target;
-    std::vector<std::pair<std::string, osg::ref_ptr<Manipulatable> > > _manipulatables;
+    std::map<std::string, osg::ref_ptr<Manipulatable> > _manipulatables;
 };
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 #ADD_DEFINITIONS(${QT_DEFINITIONS})
 
 #add_executable(plugintest plugintest.cpp)
-#target_link_libraries(plugintest Pose3dEditor)
+#target_link_libraries(plugintest pose3d_editor)
 
 #find_package(PkgConfig)
 #pkg_check_modules(EIGEN eigen3)
@@ -12,5 +12,5 @@
 #include_directories(${EIGEN_INCLUDE_DIRS} ${vizkit3d_INCLUDE_DIRS})
 
 #add_executable(vizkitest vizkittest.cpp)
-#target_link_libraries(vizkitest pose3d_editor-viz Pose3dEditor modifiable_scene ${vizkit3d_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY}
+#target_link_libraries(vizkitest pose3d_editor-viz modifiable_scene ${vizkit3d_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY}
 #  ${Boost_SYSTEM_LIBRARY})

--- a/test/vizkittest.cpp
+++ b/test/vizkittest.cpp
@@ -3,18 +3,35 @@
 #include <QApplication>
 #include "../src/Pose3dEditor.hpp"
 #include "../viz/Pose3dEditorVizkit.hpp"
+#include <vizkit3d/QVizkitMainWindow.hpp>
+#include <vizkit3d/QtThreadedWidget.hpp>
 
 int main(int argc, char** argv)
 {
     QStringList paths = QCoreApplication::libraryPaths(); for (QStringList::iterator it = paths.begin(); it!=paths.end(); it++) { std::cout << "Looking for plugins at path: " << it->toStdString() << std::endl; }
 
     QApplication app(argc, argv);
+    vizkit3d::Vizkit3DWidget* widget = new vizkit3d::Vizkit3DWidget();
+    widget->show();
 
-    vizkit3d::Pose3dEditorVizkit* widget = new vizkit3d::Pose3dEditorVizkit();
-    widget->scene()->add_movable_from_mesh_file("my_movable", "test_data/AILA_Head.STL", 0.001);
-    widget->setPosition(QVector3D(1,0,0));
 
+    //vizkit3d::Vizkit3DWidget will destroy this gui internally
+    vizkit3d::Pose3dEditorVizkit* plugin =  new vizkit3d::Pose3dEditorVizkit();
+    plugin->scene()->add_movable_from_mesh_file("my_movable", "../../test/test_data/AILA_Head.STL", 0.001);
+    plugin->setPosition(QVector3D(1,0,0));
+
+    plugin->scene()->add_movable_from_mesh_file("my_movable2", "../../test/test_data/AILA_Head.STL", 0.001);
+    plugin->setPosition(QVector3D(-1,0,0), "my_movable2");
+
+    plugin->scene()->add_movable_from_mesh_file("my_movablegone", "../../test/test_data/AILA_Head.STL", 0.001);
+    plugin->removeMovable("my_movablegone");
+
+    plugin->scene()->add_movable_from_mesh_file("my_movable3", "../../test/test_data/AILA_Head.STL", 0.001);
+    plugin->setOrientation(QQuaternion(-1,1,0,0), "my_movable3");
+
+    widget->addPlugin(plugin);
     app.exec();
+
     return 0;
 }
 

--- a/viz/Pose3dEditorVizkit.cpp
+++ b/viz/Pose3dEditorVizkit.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include "Pose3dEditorVizkit.hpp"
 #include <osg/io_utils>
+#include <sstream>
+#include <stdexcept>
 
 using namespace vizkit3d;
 
@@ -10,6 +12,27 @@ struct Pose3dEditorVizkit::Data {
     // Making a copy is required because of how OSG works
     base::samples::RigidBodyState data;
 };
+
+void to_osg(const base::samples::RigidBodyState& a, osg::Matrix& b){
+    b.setTrans(a.position.x(), a.position.y(), a.position.z());
+    b.setRotate(osg::Quat(a.orientation.x(), a.orientation.y(), a.orientation.z(), a.orientation.w()));
+}
+
+void to_osg(const base::Vector3d& a, osg::Vec3d& b){
+    b.set(a.x(), a.y(), a.z());
+}
+
+void to_osg(const base::Quaterniond& a, osg::Quat& b){
+    b.set(a.x(), a.y(), a.z(), a.w());
+}
+
+void to_osg(const QVector3D& a, osg::Vec3d& b){
+    b.set(a.x(), a.y(), a.z());
+}
+
+void to_osg(const QQuaternion& a, osg::Quat& b){
+    b.set(a.x(), a.y(), a.z(), a.scalar());
+}
 
 
 Pose3dEditorVizkit::Pose3dEditorVizkit()
@@ -41,21 +64,36 @@ void Pose3dEditorVizkit::setModelScale(double const scale){
     _modelScale=scale;
 }
 
-QVector3D Pose3dEditorVizkit::position() const {
-    if(_scene->get_transforms().size()){
-        QVector3D ret = to_qt(_scene->get_transforms()[0].second.getTrans());
-        return ret;
+osg::Matrix Pose3dEditorVizkit::get_transform(const std::string &name) const {
+    if(name == ""){
+        assert(_scene->get_transforms().size());
+        return _scene->get_transforms()[0].second;
     }
-    else
-        return QVector3D();
+    else{
+        return _scene->get_transform(name);
+    }
 }
 
-base::samples::RigidBodyState Pose3dEditorVizkit::rbs() const {
+void Pose3dEditorVizkit::set_transform(const osg::Matrix& transform, const std::string &name) const {
+    if(name == ""){
+        assert(_scene->get_transforms().size());
+        return _scene->set_transform(_scene->get_transforms()[0].first, transform);
+    }
+    else{
+        return _scene->set_transform(name, transform);
+    }
+}
+
+QVector3D Pose3dEditorVizkit::position(std::string name) const {
+    return to_qt(get_transform(name).getTrans());
+}
+
+base::samples::RigidBodyState Pose3dEditorVizkit::rbs(std::string name) const {
     base::samples::RigidBodyState ret;
 
     if(_scene->get_transforms().size()){
-        QVector3D p=position();
-        QQuaternion q = orientation();
+        QVector3D p=position(name);
+        QQuaternion q = orientation(name);
         ret.position.x() = p.x();
         ret.position.y() = p.y();
         ret.position.z() = p.z();
@@ -64,7 +102,7 @@ base::samples::RigidBodyState Pose3dEditorVizkit::rbs() const {
         ret.orientation.y() = q.y();
         ret.orientation.z() = q.z();
         ret.orientation.w() = q.scalar();
-        ret.sourceFrame = frameName().toStdString();
+        ret.sourceFrame = name;
 
         return ret;
     }
@@ -72,70 +110,52 @@ base::samples::RigidBodyState Pose3dEditorVizkit::rbs() const {
         return ret;
 }
 
-void Pose3dEditorVizkit::setRbs(const base::samples::RigidBodyState &rbs){
-    p->data = rbs;
-    updateData(p->data);
+void Pose3dEditorVizkit::setRbs(const base::samples::RigidBodyState &rbs, std::string name){
+    osg::Matrix transform;
+    to_osg(rbs, transform);
+    set_transform(transform, name);
 }
 
-void Pose3dEditorVizkit::setPosition(QVector3D const &vect){
-    p->data.position = to_eigen(vect);
-    updateData(p->data);
+void Pose3dEditorVizkit::setPosition(QVector3D const &vect, std::string name){
+    osg::Matrix transform = get_transform(name);
+    osg::Vec3d pos;
+    to_osg(vect, pos);
+    transform.setTrans(pos);
+    set_transform(transform, name);
 }
 
-QQuaternion Pose3dEditorVizkit::orientation() const {
-    if(_scene->get_transforms().size())
-        return to_qt(_scene->get_transforms()[0].second.getRotate());
-    else
-        return QQuaternion();
+QQuaternion Pose3dEditorVizkit::orientation(std::string name) const {
+    get_transform(name).getRotate();
 }
 
-void Pose3dEditorVizkit::setOrientation(QQuaternion const &quat){
-    p->data.orientation = to_eigen(quat);
-    updateData(p->data);
+void Pose3dEditorVizkit::setOrientation(QQuaternion const &quat, std::string name){
+    osg::Matrix transform = get_transform(name);
+    osg::Quat orient;
+    to_osg(quat, orient);
+    transform.setRotate(orient);
+    set_transform(transform, name);
 }
 
 double Pose3dEditorVizkit::x(){
-    if(_scene->get_transforms().size()){
-        return _scene->get_transforms()[0].second.getTrans().x();
-    }
-    else
-        return 0;
+    return position().x();
 }
 double Pose3dEditorVizkit::y(){
-    if(_scene->get_transforms().size())
-        return _scene->get_transforms()[0].second.getTrans().y();
-    else
-        return 0;
+    return position().y();
 }
 double Pose3dEditorVizkit::z(){
-    if(_scene->get_transforms().size())
-        return _scene->get_transforms()[0].second.getTrans().z();
-    else
-        return 0;
+    return position().z();
 }
 double Pose3dEditorVizkit::qx(){
-    if(_scene->get_transforms().size())
-        return _scene->get_transforms()[0].second.getRotate().x();
-    else
-        return 0;
+    return orientation().x();
 }
 double Pose3dEditorVizkit::qy(){
-    if(_scene->get_transforms().size())
-        return _scene->get_transforms()[0].second.getRotate().y();
-    else
-        return 0;
+    return orientation().y();
 }
 double Pose3dEditorVizkit::qz(){
-    if(_scene->get_transforms().size())
-        return _scene->get_transforms()[0].second.getRotate().z();
-    else
-        return 0;
+    return orientation().z();
 }
 double Pose3dEditorVizkit::qw(){
-    if(_scene->get_transforms().size())
-        return _scene->get_transforms()[0].second.getRotate().w();
-    else
-        return 0;
+    return orientation().scalar();
 }
 void Pose3dEditorVizkit::syncPose(){
     if(_scene->get_transforms().size()){
@@ -145,32 +165,39 @@ void Pose3dEditorVizkit::syncPose(){
 }
 
 void Pose3dEditorVizkit::setX(double const &val){
-    p->data.position.x() = val;
-    updateData(p->data);
+    QVector3D pos = position();
+    pos.setX(val);
+    setPosition(pos);
 }
 void Pose3dEditorVizkit::setY(double const &val){
-     p->data.position.y() = val;
-    updateData(p->data);
+    QVector3D pos = position();
+    pos.setY(val);
+    setPosition(pos);
 }
 void Pose3dEditorVizkit::setZ(double const &val){
-     p->data.position.z() = val;
-    updateData(p->data);
+    QVector3D pos = position();
+    pos.setZ(val);
+    setPosition(pos);
 }
 void Pose3dEditorVizkit::setQx(double const &val){
-     p->data.orientation.x() = val;
-    updateData(p->data);
+    QQuaternion orient = orientation();
+    orient.setX(val);
+    setOrientation(orient);
 }
 void Pose3dEditorVizkit::setQy(double const &val){
-    p->data.orientation.y() = val;
-    updateData(p->data);
+    QQuaternion orient = orientation();
+    orient.setY(val);
+    setOrientation(orient);
 }
 void Pose3dEditorVizkit::setQz(double const &val){
-    p->data.orientation.z() = val;
-    updateData(p->data);
+    QQuaternion orient = orientation();
+    orient.setZ(val);
+    setOrientation(orient);
 }
 void Pose3dEditorVizkit::setQw(double const &val){
-    p->data.orientation.w() = val;
-    updateData(p->data);
+    QQuaternion orient = orientation();
+    orient.setScalar(val);
+    setOrientation(orient);
 }
 
 
@@ -226,14 +253,9 @@ void Pose3dEditorVizkit::updateMainNode ( osg::Node* node )
      _scene = static_cast< modifiable_scene::Scene*>(node);
     // Update the main node using the data in p->data
      osg::Matrix transform;
-     transform.setTrans(p->data.position.x(), p->data.position.y(), p->data.position.z());
-     transform.setRotate(osg::Quat(p->data.orientation.x(), p->data.orientation.y(), p->data.orientation.z(), p->data.orientation.w()));
+     to_osg(p->data, transform);
      osg::ref_ptr<modifiable_scene::Manipulatable> manipulatable = _scene->manipulatable(_frameName.toStdString());
-     if(!manipulatable){
-         std::stringstream ss;
-         ss << "No manipulatable with name '" << p->data.sourceFrame << "' was found.";
-         throw(std::runtime_error(ss.str()));
-     }
+
      manipulatable->set_transform(transform);
      std::cout << "Update: " << p->data.position.x()<<std::endl;
 }

--- a/viz/Pose3dEditorVizkit.cpp
+++ b/viz/Pose3dEditorVizkit.cpp
@@ -64,7 +64,7 @@ base::samples::RigidBodyState Pose3dEditorVizkit::rbs() const {
         ret.orientation.y() = q.y();
         ret.orientation.z() = q.z();
         ret.orientation.w() = q.scalar();
-        ret.sourceFrame = frameName().toLatin1().data();
+        ret.sourceFrame = frameName().toStdString();
 
         return ret;
     }
@@ -192,7 +192,7 @@ void Pose3dEditorVizkit::setFrameName(QString frame_name)
         throw("a frame name was already set");
     }
     _frameName = frame_name;
-    p->data.sourceFrame = _frameName.toLatin1().data();
+    p->data.sourceFrame = _frameName.toStdString();
 
     addMovable(_frameName, _modelFile, _modelScale);
 }
@@ -201,12 +201,18 @@ void Pose3dEditorVizkit::setFrameName(QString frame_name)
 void Pose3dEditorVizkit::addMovable(QString name, QString model_file, double scale)
 {
     if(_frameName!="" && _modelFile!=""){
-        std::cout << "adding"<<std::endl;
-        _scene->add_movable_from_mesh_file(name.toLatin1().data(), model_file.toLatin1().data(), scale);
+        std::cout << "adding " << name.toStdString() <<std::endl;
+        _scene->add_movable_from_mesh_file(name.toStdString(), model_file.toStdString(), scale);
         emit childrenChanged();
         std::cout << "added"<<std::endl;
     }
 }
+
+void Pose3dEditorVizkit::removeMovable(QString name) 
+{
+    _scene->remove_movable(name.toStdString());
+}
+
 
 osg::ref_ptr<osg::Node> Pose3dEditorVizkit::createMainNode()
 {
@@ -222,7 +228,7 @@ void Pose3dEditorVizkit::updateMainNode ( osg::Node* node )
      osg::Matrix transform;
      transform.setTrans(p->data.position.x(), p->data.position.y(), p->data.position.z());
      transform.setRotate(osg::Quat(p->data.orientation.x(), p->data.orientation.y(), p->data.orientation.z(), p->data.orientation.w()));
-     osg::ref_ptr<modifiable_scene::Manipulatable> manipulatable = _scene->manipulatable(_frameName.toLatin1().data());
+     osg::ref_ptr<modifiable_scene::Manipulatable> manipulatable = _scene->manipulatable(_frameName.toStdString());
      if(!manipulatable){
          std::stringstream ss;
          ss << "No manipulatable with name '" << p->data.sourceFrame << "' was found.";

--- a/viz/Pose3dEditorVizkit.hpp
+++ b/viz/Pose3dEditorVizkit.hpp
@@ -70,6 +70,7 @@ public slots:
 
 
     Q_INVOKABLE void addMovable(QString const name, QString const model_file, double scale=1.0f);
+    Q_INVOKABLE void removeMovable(QString name);
 
     Q_INVOKABLE void updateData( base::samples::RigidBodyState const &sample)
     {vizkit3d::Vizkit3DPlugin<base::samples::RigidBodyState>::updateData(sample);}

--- a/viz/Pose3dEditorVizkit.hpp
+++ b/viz/Pose3dEditorVizkit.hpp
@@ -21,12 +21,33 @@ class Pose3dEditorVizkit
     Q_PROPERTY(QString modelFile READ modelFile WRITE setModelFile)
     Q_PROPERTY(QString frameName READ frameName WRITE setFrameName)
     Q_PROPERTY(double modelScale READ modelScale WRITE setModelScale)
+    /**
+     * @deprecated
+     */
     Q_PROPERTY(double x READ x WRITE setX)
+    /**
+     * @deprecated
+     */
     Q_PROPERTY(double y READ y WRITE setY)
+    /**
+     * @deprecated
+     */
     Q_PROPERTY(double z READ z WRITE setZ)
+    /**
+     * @deprecated
+     */
     Q_PROPERTY(double qx READ qx WRITE setQx)
+    /**
+     * @deprecated
+     */
     Q_PROPERTY(double qy READ qy WRITE setQy)
+    /**
+     * @deprecated
+     */
     Q_PROPERTY(double qz READ qz WRITE setQz)
+    /**
+     * @deprecated
+     */
     Q_PROPERTY(double qw READ qw WRITE setQw)
 
 public:
@@ -41,31 +62,73 @@ public:
     void setModelScale(double const scale);
     double modelScale() const{return _modelScale;}
 
+    /**
+     * @deprecated
+     */
     double x();
+    /**
+     * @deprecated
+     */
     double y();
+    /**
+     * @deprecated
+     */
     double z();
+    /**
+     * @deprecated
+     */
     double qx();
+    /**
+     * @deprecated
+     */
     double qy();
+    /**
+     * @deprecated
+     */
     double qz();
+    /**
+     * @deprecated
+     */
     double qw();
+    /**
+     * @deprecated
+     */
     void setX(double const &val);
+    /**
+     * @deprecated
+     */
     void setY(double const &val);
+    /**
+     * @deprecated
+     */
     void setZ(double const &val);
+    /**
+     * @deprecated
+     */
     void setQx(double const &val);
+    /**
+     * @deprecated
+     */
     void setQy(double const &val);
+    /**
+     * @deprecated
+     */
     void setQz(double const &val);
+    /**
+     * @deprecated
+     */
     void setQw(double const &val);
 
 public slots:
     void syncPose();
 
 
-    QVector3D position() const;
-    void setPosition(QVector3D const &vect);
-    QQuaternion orientation() const;
-    void setOrientation(QQuaternion const &quat);
-    base::samples::RigidBodyState rbs() const;
-    void setRbs(base::samples::RigidBodyState const &rbs);
+    QVector3D position(std::string name="") const;
+    void setPosition(QVector3D const &vect, std::string name="");
+    QQuaternion orientation(std::string name="") const;
+    void setOrientation(QQuaternion const &quat, std::string name="");
+    base::samples::RigidBodyState rbs(std::string name="") const;
+    void setRbs(base::samples::RigidBodyState const &rbs, std::string name="");
 
 
 
@@ -103,6 +166,11 @@ protected:
     inline Eigen::Quaterniond to_eigen(QQuaternion const quat) const {
         return Eigen::Quaterniond(quat.scalar(), quat.x(), quat.y(), quat.z());
     }
+
+    //If no name is given automatically first transform is returned. This is for backwards compatibility and deprecated
+    osg::Matrix get_transform(const std::string& name) const;
+    //If no name is given automatically first transform is set. This is for backwards compatibility and deprecated
+    void set_transform(const osg::Matrix& transform, const std::string &name) const;
 
 private:
     struct Data;


### PR DESCRIPTION
This includes #1, but additionally also to set and get transforms for multiple movables. This PR deprecates the 'old' assumption of the Vizkit Plugin of only working with a single movable in the scene.
