### PR TITLE
Switch to three axis dragger instead of dual plane and allow configuration of manipulator

### DIFF
--- a/src/modifiable_scene/CMakeLists.txt
+++ b/src/modifiable_scene/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
-set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE Debug)
 
 FIND_PACKAGE(OpenSceneGraph REQUIRED osgManipulator osgViewer osgDB osgUtil osgGA osgText)
 find_package(PkgConfig)

--- a/src/modifiable_scene/dragger.cpp
+++ b/src/modifiable_scene/dragger.cpp
@@ -1,51 +1,60 @@
 #include "dragger.h"
 #include <osg/Material>
 #include <osg/BlendFunc>
+#include <math.h>
 
 namespace modifiable_scene{
 
-DualPlaneDragger::DualPlaneDragger(osg::Matrixd world_coords)
+TripleLineDragger::TripleLineDragger(osg::Matrixd world_coords)
 {
     osg::Quat q=world_coords.getRotate();
-    osg::Vec3f z = q*osg::Vec3f(0.f,0.f,1.f);
-    osg::Vec3f y = q*osg::Vec3f(0.f,1.f,0.f);
-    _plane_dragger1 = new osgManipulator::Translate2DDragger(osg::Plane(z, 0.f));
-    _plane_dragger1->setColor(osg::Vec4f(0,0,1,1));
-    _plane_dragger1->setPickColor(osg::Vec4f(0,0,1,1));
-    _plane_dragger2 = new osgManipulator::Translate2DDragger(osg::Plane(y, 0.f));
-    _plane_dragger2->setColor(osg::Vec4f(0,1,0,1));
-    _plane_dragger2->setPickColor(osg::Vec4f(0,1,0,1));
+    _line_dragger1 = new osgManipulator::Translate1DDragger(q*osg::Vec3(-0.5,0.0,0.0), q*osg::Vec3(0.5,0.0,0.0));
+    _line_dragger2 = new osgManipulator::Translate1DDragger(q*osg::Vec3(0.0,-0.5,0.0), q*osg::Vec3(0.0,0.5,0.0));
 
-    addChild(_plane_dragger1.get());
-    addDragger(_plane_dragger1.get());
-    addChild(_plane_dragger2.get());
-    addDragger(_plane_dragger2.get());
+    //One end is upside down
+    //_line_dragger3 = new osgManipulator::Translate1DDragger(q*osg::Vec3(0.0,0.0,-0.5), q*osg::Vec3(0.0,0.0,0.5));
 
-    _plane_dragger1->setParentDragger(getParentDragger());
-    _plane_dragger2->setParentDragger(getParentDragger());
+    //Workaround to prevent one end of the dragger to be upside down
+    _line_dragger3 = new osgManipulator::Translate1DDragger(q*osg::Vec3(-0.5,0.0,0.0), q*osg::Vec3(0.5,0.0,0.0));
+    _line_dragger3->setMatrix(_line_dragger3->getMatrix().rotate(M_PI_2,0,1,0));
+
+    _line_dragger1->setColor(osg::Vec4f(1,0,0,1));
+    _line_dragger1->setPickColor(osg::Vec4f(1,0,0,1));
+    _line_dragger2->setColor(osg::Vec4f(0,1,0,1));
+    _line_dragger2->setPickColor(osg::Vec4f(0,1,0,1));
+    _line_dragger3->setColor(osg::Vec4f(0,0,1,1));
+    _line_dragger3->setPickColor(osg::Vec4f(0,0,1,1));
+
+    addChild(_line_dragger1.get());
+    addDragger(_line_dragger1.get());
+    addChild(_line_dragger2.get());
+    addDragger(_line_dragger2.get());
+    addChild(_line_dragger3.get());
+    addDragger(_line_dragger3.get());
+
+    _line_dragger1->setParentDragger(getParentDragger());
+    _line_dragger2->setParentDragger(getParentDragger());
+    _line_dragger3->setParentDragger(getParentDragger());
 }
 
-void DualPlaneDragger::setColor(const osg::Vec4 &color)
+void TripleLineDragger::setColor(const osg::Vec4 &color)
 {
-    _plane_dragger1->setColor(color);
-    _plane_dragger2->setColor(color);
+    _line_dragger1->setColor(color);
+    _line_dragger2->setColor(color);
+    _line_dragger3->setColor(color);
 }
 
-/*
-void DualPlaneDragger::setParentDragger(Dragger *parent){
-    _plane_dragger1->setParentDragger(parent);
-    _plane_dragger2->setParentDragger(parent);
-}
-*/
-DualPlaneDragger::~DualPlaneDragger(){
+TripleLineDragger::~TripleLineDragger(){
 
 }
 
 
-void DualPlaneDragger::setupDefaultGeometry()
+void TripleLineDragger::setupDefaultGeometry()
 {
-    _plane_dragger1->setupDefaultGeometry();
-    _plane_dragger2->setupDefaultGeometry();
+    _line_dragger1->setupDefaultGeometry();
+    _line_dragger2->setupDefaultGeometry();
+    _line_dragger3->setupDefaultGeometry();
+
 }
 
 Dragger::Dragger(osg::Matrixd world_coords)
@@ -56,7 +65,7 @@ Dragger::Dragger(osg::Matrixd world_coords)
 
     osg::MatrixTransform* tr = new osg::MatrixTransform();
     tr->setMatrix(osg::Matrix::scale(2.1,2.1,2.1));
-    _position_dragger = new DualPlaneDragger(world_coords);
+    _position_dragger = new TripleLineDragger(world_coords);
     tr->addChild(_position_dragger);
     addChild(tr);
     addDragger(_position_dragger.get());

--- a/src/modifiable_scene/dragger.cpp
+++ b/src/modifiable_scene/dragger.cpp
@@ -4,10 +4,18 @@
 
 namespace modifiable_scene{
 
-DualPlaneDragger::DualPlaneDragger()
+DualPlaneDragger::DualPlaneDragger(osg::Matrixd world_coords)
 {
-    _plane_dragger1 = new osgManipulator::Translate2DDragger(osg::Plane(osg::Vec3f(0.f, 0.f, 1.f), 1.f));
-    _plane_dragger2 = new osgManipulator::Translate2DDragger(osg::Plane(osg::Vec3f(0.f, 1.f, 0.f), 1.f));
+    osg::Quat q=world_coords.getRotate();
+    osg::Vec3f z = q*osg::Vec3f(0.f,0.f,1.f);
+    osg::Vec3f y = q*osg::Vec3f(0.f,1.f,0.f);
+    _plane_dragger1 = new osgManipulator::Translate2DDragger(osg::Plane(z, 0.f));
+    _plane_dragger1->setColor(osg::Vec4f(0,0,1,1));
+    _plane_dragger1->setPickColor(osg::Vec4f(0,0,1,1));
+    _plane_dragger2 = new osgManipulator::Translate2DDragger(osg::Plane(y, 0.f));
+    _plane_dragger2->setColor(osg::Vec4f(0,1,0,1));
+    _plane_dragger2->setPickColor(osg::Vec4f(0,1,0,1));
+
     addChild(_plane_dragger1.get());
     addDragger(_plane_dragger1.get());
     addChild(_plane_dragger2.get());
@@ -40,7 +48,7 @@ void DualPlaneDragger::setupDefaultGeometry()
     _plane_dragger2->setupDefaultGeometry();
 }
 
-Dragger::Dragger()
+Dragger::Dragger(osg::Matrixd world_coords)
 {
     _orientation_dragger = new TrackballDragger(false);
     addChild(_orientation_dragger.get());
@@ -48,7 +56,7 @@ Dragger::Dragger()
 
     osg::MatrixTransform* tr = new osg::MatrixTransform();
     tr->setMatrix(osg::Matrix::scale(2.1,2.1,2.1));
-    _position_dragger = new DualPlaneDragger();
+    _position_dragger = new DualPlaneDragger(world_coords);
     tr->addChild(_position_dragger);
     addChild(tr);
     addDragger(_position_dragger.get());

--- a/src/modifiable_scene/dragger.h
+++ b/src/modifiable_scene/dragger.h
@@ -13,7 +13,7 @@ class DualPlaneDragger: public osgManipulator::CompositeDragger
         osg::ref_ptr<osgManipulator::Translate2DDragger> _plane_dragger1;
         osg::ref_ptr<osgManipulator::Translate2DDragger> _plane_dragger2;
 
-        DualPlaneDragger();
+        DualPlaneDragger(osg::Matrixd world_coords);
         ~DualPlaneDragger();
 
         void setupDefaultGeometry();
@@ -32,7 +32,7 @@ class Dragger : public osgManipulator::CompositeDragger
 public:
     osg::ref_ptr<TrackballDragger> _orientation_dragger;
     osg::ref_ptr<DualPlaneDragger> _position_dragger;
-    Dragger();
+    Dragger(osg::Matrixd world_coords);
 
     ~Dragger();
 

--- a/src/modifiable_scene/dragger.h
+++ b/src/modifiable_scene/dragger.h
@@ -3,18 +3,20 @@
 
 #include <osgManipulator/Dragger>
 #include <osgManipulator/TrackballDragger>
-#include <osgManipulator/Translate2DDragger>
+#include <osgManipulator/Translate1DDragger>
+
 
 namespace modifiable_scene{
 
-class DualPlaneDragger: public osgManipulator::CompositeDragger
+class TripleLineDragger: public osgManipulator::CompositeDragger
 {
     public:
-        osg::ref_ptr<osgManipulator::Translate2DDragger> _plane_dragger1;
-        osg::ref_ptr<osgManipulator::Translate2DDragger> _plane_dragger2;
+        osg::ref_ptr<osgManipulator::Translate1DDragger> _line_dragger1;
+        osg::ref_ptr<osgManipulator::Translate1DDragger> _line_dragger2;
+        osg::ref_ptr<osgManipulator::Translate1DDragger> _line_dragger3;
 
-        DualPlaneDragger(osg::Matrixd world_coords);
-        ~DualPlaneDragger();
+        TripleLineDragger(osg::Matrixd world_coords);
+        ~TripleLineDragger();
 
         void setupDefaultGeometry();
         void setColor(const osg::Vec4& color);
@@ -31,7 +33,7 @@ class Dragger : public osgManipulator::CompositeDragger
 {
 public:
     osg::ref_ptr<TrackballDragger> _orientation_dragger;
-    osg::ref_ptr<DualPlaneDragger> _position_dragger;
+    osg::ref_ptr<TripleLineDragger> _position_dragger;
     Dragger(osg::Matrixd world_coords);
 
     ~Dragger();

--- a/src/modifiable_scene/manipulatable.cpp
+++ b/src/modifiable_scene/manipulatable.cpp
@@ -46,7 +46,7 @@ void Manipulatable::set_transform(const osg::Matrix& transform){
     else{
         scale = _config.absolute_dragger_size;
     }
-    osg::Matrix mat = osg::Matrix::scale(scale, scale, scale) * osg::Matrix::translate(transform.getTrans());
+    osg::Matrix mat = osg::Matrix::scale(scale, scale, scale) * osg::Matrix::rotate(transform.getRotate()) * osg::Matrix::translate(transform.getTrans()) ;
     _dragger->setMatrix(mat);
 }
 

--- a/src/modifiable_scene/manipulatable.cpp
+++ b/src/modifiable_scene/manipulatable.cpp
@@ -2,13 +2,25 @@
 #include <osg/io_utils>
 
 namespace modifiable_scene{
-Manipulatable::Manipulatable(osg::ref_ptr<osg::Node> manipulatable_node)
+Manipulatable::Manipulatable(osg::ref_ptr<osg::Node> manipulatable_node, const Config& cfg, osg::ref_ptr<osg::Node> attachment)
 {
-    _dragger = new Dragger();
-    _dragger->setupDefaultGeometry();
-
+    _config = cfg;
     _manipulatable_node = manipulatable_node;
     _transform = new osg::MatrixTransform();
+
+    osg::Matrixd mat;
+    if(attachment){
+        mat = getWorldCoords(attachment);
+        mat = osg::Matrixd::identity();
+    }
+    else{
+        mat = osg::Matrixd::identity();
+    }
+
+    osg::Quat q = mat.getRotate();
+    _dragger = new Dragger(mat);
+    _dragger->setupDefaultGeometry();
+
 
     manipulatable_node->getOrCreateStateSet()->setMode(GL_NORMALIZE, osg::StateAttribute::ON);
     _transform->addChild(_manipulatable_node);
@@ -16,19 +28,24 @@ Manipulatable::Manipulatable(osg::ref_ptr<osg::Node> manipulatable_node)
     this->addChild(_transform);
     this->addChild(_dragger);
 
-    set_transform(osg::Matrix::identity());
-
     _dragger->setHandleEvents(true);
     _dragger->setActivationModKeyMask(osgGA::GUIEventAdapter::MODKEY_CTRL);
 
     _dragger->addTransformUpdating(_transform);
+
+    set_transform(osg::Matrix::identity());
 }
 
-void Manipulatable::set_transform(osg::Matrix transform){
+void Manipulatable::set_transform(const osg::Matrix& transform){
     _transform->setMatrix(transform);
 
-    float scale = _manipulatable_node->getBound().radius() * 1.5;
-    //osg::Matrix mat = osg::Matrix::scale(scale, scale, scale) * osg::Matrix::translate(_manipulatable_node->getBound().center() * transform);
+    float scale;
+    if(_config.auto_scale_dragger){
+        scale = _manipulatable_node->getBound().radius() * _config.auto_scale_factor;
+    }
+    else{
+        scale = _config.absolute_dragger_size;
+    }
     osg::Matrix mat = osg::Matrix::scale(scale, scale, scale) * osg::Matrix::translate(transform.getTrans());
     _dragger->setMatrix(mat);
 }

--- a/src/modifiable_scene/manipulatable.h
+++ b/src/modifiable_scene/manipulatable.h
@@ -5,19 +5,80 @@
 #include "dragger.h"
 
 namespace modifiable_scene{
+// Visitor to return the world coordinates of a node.
+// It traverses from the starting node to the parent.
+// The first time it reaches a root node, it stores the world coordinates of
+// the node it started from.  The world coordinates are found by concatenating all
+// the matrix transforms found on the path from the start node to the root node.
+class getWorldCoordOfNodeVisitor : public osg::NodeVisitor
+{
+public:
+    getWorldCoordOfNodeVisitor():
+        osg::NodeVisitor(NodeVisitor::TRAVERSE_PARENTS), done(false)
+    {
+    }
+    virtual void apply(osg::Node &node)
+    {
+        if (!done)
+        {
+            if ( 0 == node.getNumParents() ) // no parents
+            {
+                wcMatrix.set( osg::computeLocalToWorld(this->getNodePath()) );
+                done = true;
+            }
+            traverse(node);
+        }
+    }
+    osg::Matrixd& giveUpDaMat()
+    {
+        return wcMatrix;
+    }
+private:
+    bool done;
+    osg::Matrixd wcMatrix;
+};
+
+// Given a valid node placed in a scene under a transform, return the
+// world coordinates in an osg::Matrix.
+// Creates a visitor that will update a matrix representing world coordinates
+// of the node, return this matrix.
+// (This could be a class member for something derived from node also.
+inline osg::Matrixd& getWorldCoords( osg::Node* node)
+{
+    getWorldCoordOfNodeVisitor* ncv = new getWorldCoordOfNodeVisitor();
+    if (node && ncv)
+    {
+        node->accept(*ncv);
+        return ncv->giveUpDaMat();
+    }
+    else
+    {
+        throw("Could not find world coords for node");
+    }
+}
+
 class Manipulatable : public osg::Group
 {
 public:
-    Manipulatable(osg::ref_ptr<osg::Node> manipulatable_node);
+    struct Config{
+        Config(bool auto_scale_dragger=true, float auto_scale_factor=1.5, float absolute_dragger_size=1.0):
+            auto_scale_dragger(auto_scale_dragger), auto_scale_factor(auto_scale_factor), absolute_dragger_size(absolute_dragger_size)
+        {}
+        bool auto_scale_dragger;
+        float auto_scale_factor;
+        float absolute_dragger_size;
+    };
 
-    void set_transform(osg::Matrix transform);
+    Manipulatable(osg::ref_ptr<osg::Node> manipulatable_node, const Config& cfg=Config(), osg::ref_ptr<osg::Node> attachment=0);
     osg::Matrix get_transform();
 
-    osg::ref_ptr<osgManipulator::Dragger> _dragger;
+    void set_transform(const osg::Matrix& transform);
 
+public:
+    osg::ref_ptr<osgManipulator::Dragger> _dragger;
     osg::ref_ptr<osg::Node> _manipulatable_node;
     osg::ref_ptr<osg::MatrixTransform> _transform;
-    //osg::ref_ptr<osg::Group> _root;
+    Config _config;
 };
 }
 

--- a/src/modifiable_scene/scene.h
+++ b/src/modifiable_scene/scene.h
@@ -17,16 +17,21 @@ public:
 
     std::vector<std::pair<std::string, osg::Matrix> > get_transforms();
     osg::Matrix get_transform(std::string name);
-    void add_movable(std::string name, osg::ref_ptr<osg::Node> scene);
-    void add_movable_from_mesh_file(std::string name, std::string filepath, double scale=1.f);
+    void add_movable(std::string name, osg::ref_ptr<osg::Node> scene, Manipulatable::Config config=Manipulatable::Config());
+    void add_movable_from_mesh_file(std::string name, std::string filepath, double scale=1.f, Manipulatable::Config config=Manipulatable::Config());
 
     inline SceneItem& target(){return _target;}
     osg::ref_ptr<Manipulatable> manipulatable(std::string name);
 
+    osg::ref_ptr<osg::Group> empty_scene();
+    osg::ref_ptr<osg::Group> default_root_scene();
+    void set_root_scene(osg::ref_ptr<osg::Group> root_scene);
 
-private:
+
+protected:
     SceneItem _target;
     std::vector<std::pair<std::string, osg::ref_ptr<Manipulatable> > > _manipulatables;
+    osg::ref_ptr<osg::Group> _root_scene;
 };
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,16 @@
-#FIND_PACKAGE(Qt4 REQUIRED QtCore QtGui QtOpenGL)
-#INCLUDE(${QT_USE_FILE})
-#ADD_DEFINITIONS(${QT_DEFINITIONS})
+FIND_PACKAGE(Qt4 REQUIRED QtCore QtGui QtOpenGL)
+INCLUDE(${QT_USE_FILE})
+ADD_DEFINITIONS(${QT_DEFINITIONS})
 
-#add_executable(plugintest plugintest.cpp)
-#target_link_libraries(plugintest Pose3dEditor)
+add_executable(plugintest plugintest.cpp)
+target_link_libraries(plugintest pose3d_editor)
 
-#find_package(PkgConfig)
-#pkg_check_modules(EIGEN eigen3)
-#pkg_check_modules(vizkit3d vizkit3d)
-#find_package(Boost COMPONENTS system filesystem REQUIRED)
-#include_directories(${EIGEN_INCLUDE_DIRS} ${vizkit3d_INCLUDE_DIRS})
+find_package(PkgConfig)
+pkg_check_modules(EIGEN eigen3)
+pkg_check_modules(vizkit3d vizkit3d)
+find_package(Boost COMPONENTS system filesystem REQUIRED)
+include_directories(${EIGEN_INCLUDE_DIRS} ${vizkit3d_INCLUDE_DIRS})
 
-#add_executable(vizkitest vizkittest.cpp)
-#target_link_libraries(vizkitest pose3d_editor-viz Pose3dEditor modifiable_scene ${vizkit3d_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY}
-#  ${Boost_SYSTEM_LIBRARY})
+add_executable(vizkitest vizkittest.cpp)
+target_link_libraries(vizkitest pose3d_editor-viz pose3d_editor modifiable_scene ${vizkit3d_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY})

--- a/test/test_vizkit3d.rb
+++ b/test/test_vizkit3d.rb
@@ -5,13 +5,22 @@ view3d = Vizkit.vizkit3d_widget
 view3d.show
 vis = Vizkit.default_loader.Pose3dEditorVizkit
 #binding.pry
-vis.frameName="my_movable"
+
+vis.frameName="Interaction Frame"
+vis.frame = 'world_osg'
 vis.modelScale=0.001
-vis.modelFile="test_data/AILA_Head.STL"
+
+timer = Qt::Timer.new
+timer.setSingleShot(true)
+timer.start(4000)
+timer.connect(SIGNAL('timeout()')) do
+    vis.modelFile="test_data/AILA_Head.STL"
+end
 
 btn=Qt::PushButton.new("Random Move")
 btn.show
 btn.connect(SIGNAL("clicked()")) do
+
 	puts "READ"
 	rbs = vis.rbs()
 	puts "got this:"

--- a/test/vizkittest.cpp
+++ b/test/vizkittest.cpp
@@ -11,7 +11,9 @@ int main(int argc, char** argv)
     QApplication app(argc, argv);
 
     vizkit3d::Pose3dEditorVizkit* widget = new vizkit3d::Pose3dEditorVizkit();
-    widget->scene()->add_movable_from_mesh_file("my_movable", "test_data/AILA_Head.STL", 0.001);
+
+    widget->setFrameName("bla");
+    widget->setModelFile("test_data/AILA_Head.STL");
     widget->setPosition(QVector3D(1,0,0));
 
     app.exec();

--- a/viz/Pose3dEditorVizkit.cpp
+++ b/viz/Pose3dEditorVizkit.cpp
@@ -201,10 +201,8 @@ void Pose3dEditorVizkit::setFrameName(QString frame_name)
 void Pose3dEditorVizkit::addMovable(QString name, QString model_file, double scale)
 {
     if(_frameName!="" && _modelFile!=""){
-        std::cout << "adding"<<std::endl;
-        _scene->add_movable_from_mesh_file(name.toLatin1().data(), model_file.toLatin1().data(), scale);
+        _scene->add_movable_from_mesh_file(name.toStdString(), model_file.toLatin1().data(), scale);
         emit childrenChanged();
-        std::cout << "added"<<std::endl;
     }
 }
 
@@ -217,25 +215,25 @@ osg::ref_ptr<osg::Node> Pose3dEditorVizkit::createMainNode()
 
 void Pose3dEditorVizkit::updateMainNode ( osg::Node* node )
 {
-     _scene = static_cast< modifiable_scene::Scene*>(node);
-    // Update the main node using the data in p->data
-     osg::Matrix transform;
-     transform.setTrans(p->data.position.x(), p->data.position.y(), p->data.position.z());
-     transform.setRotate(osg::Quat(p->data.orientation.x(), p->data.orientation.y(), p->data.orientation.z(), p->data.orientation.w()));
-     osg::ref_ptr<modifiable_scene::Manipulatable> manipulatable = _scene->manipulatable(_frameName.toLatin1().data());
-     if(!manipulatable){
-         std::stringstream ss;
-         ss << "No manipulatable with name '" << p->data.sourceFrame << "' was found.";
-         throw(std::runtime_error(ss.str()));
-     }
-     manipulatable->set_transform(transform);
-     std::cout << "Update: " << p->data.position.x()<<std::endl;
+    _scene = static_cast< modifiable_scene::Scene*>(node);
 }
 
 void Pose3dEditorVizkit::updateDataIntern( base::samples::RigidBodyState const& value)
 {
     p->data = value;
-    std::cout << "Update intern: " << p->data.position.x()<<","<<value.position.x()<<std::endl;
+
+    // Update the main node using the data in p->data
+    osg::Matrix transform;
+    transform.setTrans(p->data.position.x(), p->data.position.y(), p->data.position.z());
+    transform.setRotate(osg::Quat(p->data.orientation.x(), p->data.orientation.y(), p->data.orientation.z(), p->data.orientation.w()));
+    osg::ref_ptr<modifiable_scene::Manipulatable> manipulatable = _scene->manipulatable(_frameName.toStdString());
+    if(!manipulatable){
+        std::stringstream ss;
+        ss << "No manipulatable with name '" << p->data.sourceFrame << "' was found.";
+        throw(std::runtime_error(ss.str()));
+    }
+    manipulatable->set_transform(transform);
+    std::cout << "Update: " << p->data.position.x()<<std::endl;
     emit childrenChanged();
 }
 


### PR DESCRIPTION
Instead of using dual axis dragger we switch to a single dragger per axis. This should result in more predictable behavior while manipulating movables.

Also sizes of draggers are now adjustable bugfixes regarding 'old' single movable assumption are included.
